### PR TITLE
addToCart() bug fix

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -318,7 +318,7 @@ client.prototype.addToCart = function(params, callback){
         return callback("params is missing required modelId parameter");
     }
 
-    this.post(this.url("/orders/cart/", params), null, callback);
+    this.post(this.url("/orders/cart/"), JSON.stringify(params), callback);
 };
 
 /**


### PR DESCRIPTION
`addToCart` method is currently incorrectly calling the API (specifically it is incorrectly passing the parameters). Changed the call to reflect other post methods in the code.