### PR TITLE
Specify "application/json" content-type for POST/PUT requests

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -220,8 +220,14 @@ client.prototype.delete = function(url, callback){
  * @param {string} [body] - the POST body data to send with the request
  * @param {client~resultsCallback} [callback] - function to call when finished
  **/
-client.prototype.post = function(url, body, callback){
-    if(typeof(body) == "function"){
+client.prototype.post = function(url, body, content_type, callback){
+    
+    if(typeof(content_type) === "function"){
+        callback = content_type;
+        content_type = null;
+    }
+
+    if(typeof(body) === "function"){
         callback = body;
         body = null;
     }
@@ -234,7 +240,7 @@ client.prototype.post = function(url, body, callback){
         return callback("no oauth token, make sure to call client.connect and client.verify");
     }
 
-    this.connection.post(url, this.oauthToken, this.oauthSecret, body, function(error, data, result){
+    this.connection.post(url, this.oauthToken, this.oauthSecret, body, content_type, function(error, data, result){
         if(error){
             return callback(error);
         }
@@ -254,8 +260,14 @@ client.prototype.post = function(url, body, callback){
  * @param {string} [body] - the PUT body data to send with the request
  * @param {client~resultsCallback} [callback] - function to call when finished
  **/
-client.prototype.put = function(url, body, callback){
-    if(typeof(body) == "function"){
+client.prototype.put = function(url, body, content_type, callback){
+    
+    if(typeof(content_type) === "function"){
+        callback = content_type;
+        content_type = null;
+    }
+    
+    if(typeof(body) === "function"){
         callback = body;
         body = null;
     }
@@ -268,7 +280,7 @@ client.prototype.put = function(url, body, callback){
         return callback("no oauth token, make sure to call client.connect and client.verify");
     }
 
-    this.connection.put(url, this.oauthToken, this.oauthSecret, body, function(error, data, result){
+    this.connection.put(url, this.oauthToken, this.oauthSecret, body, content_type, function(error, data, result){
         if(error){
             return callback(error);
         }
@@ -318,7 +330,7 @@ client.prototype.addToCart = function(params, callback){
         return callback("params is missing required modelId parameter");
     }
 
-    this.post(this.url("/orders/cart/", params), null, callback);
+    this.post(this.url("/orders/cart/", params), null, null, callback);
 };
 
 /**
@@ -410,7 +422,7 @@ client.prototype.addModel = function(params, callback){
     }
 
     params.file = this.connection._encodeData(new Buffer(params.file).toString("base64"));
-    this.post(this.url("/models/"), JSON.stringify(params), callback);
+    this.post(this.url("/models/"), JSON.stringify(params), "application/json", callback);
 };
 
 /**
@@ -453,7 +465,7 @@ client.prototype.deleteModel = function(modelId, callback){
  * @param {client~resultsCallback} [callback] - function to call when finished
  **/
 client.prototype.updateModelInfo = function(modelId, params, callback){
-    this.put(this.url("/models/" + modelId), JSON.stringify(params), callback);
+    this.put(this.url("/models/" + modelId), JSON.stringify(params), "application/json", callback);
 };
 
 /**
@@ -498,7 +510,7 @@ client.prototype.addModelPhoto = function(modelId, params, callback){
     }
 
     params.file = this.connection._encodeData(new Buffer(params.file).toString("base64"));
-    this.post(this.url("/models/" + modelId + "/photos/"), JSON.stringify(params), callback);
+    this.post(this.url("/models/" + modelId + "/photos/"), JSON.stringify(params), "application/json", callback);
 };
 
 /**
@@ -527,7 +539,7 @@ client.prototype.addModelFile = function(modelId, params, callback){
     }
 
     params.file = this.connection._encodeData(new Buffer(params.file).toString("base64"));
-    this.post(this.url("/models/" + modelId + "/files/"), JSON.stringify(params), callback);
+    this.post(this.url("/models/" + modelId + "/files/"), JSON.stringify(params), "application/json", callback);
 };
 
 /**
@@ -606,7 +618,7 @@ client.prototype.getPrice = function(params, callback){
         return callback("error, params missing required properties: " + missing);
     }
 
-    this.post(this.url("/price/"), JSON.stringify(params), callback);
+    this.post(this.url("/price/"), JSON.stringify(params), "application/json", callback);
 };
 
 module.exports = client;

--- a/test/client/api.js
+++ b/test/client/api.js
@@ -55,9 +55,10 @@ suite("Shapeways.Client", function(){
 
         test("should build the correct url with qs and call client.get", function(done){
             var old_post = shapeways.client.prototype.post;
-            shapeways.client.prototype.post = function(url, body, callback){
+            shapeways.client.prototype.post = function(url, body, content_type, callback){
                 assert.equal(url, "https://api.shapeways.com/orders/cart/v1?modelId=86");
                 assert.equal(body, null);
+                assert.equal(content_type, null);
                 callback(null, {});
             };
 
@@ -285,9 +286,10 @@ suite("Shapeways.Client", function(){
     suite("client.getPrice", function(){
         test("should build the correct url and call client.post", function(done){
             var old_post = shapeways.client.prototype.post;
-            shapeways.client.prototype.post = function(url, body, callback){
+            shapeways.client.prototype.post = function(url, body, content_type, callback){
                 assert.equal(url, "https://api.shapeways.com/price/v1");
                 assert.equal(typeof(body), "string");
+                assert.equal(typeof(content_type), "string");
                 callback(null, {});
             };
 
@@ -313,9 +315,10 @@ suite("Shapeways.Client", function(){
 
         test("should call get an error with missing params", function(done){
             var old_post = shapeways.client.prototype.post;
-            shapeways.client.prototype.post = function(url, body, callback){
+            shapeways.client.prototype.post = function(url, body, content_type, callback){
                 assert.equal(url, "https://api.shapeways.com/price/v1");
                 assert.equal(typeof(body), "string");
+                assert.equal(typeof(content_type), "string");
                 callback(null, {});
             };
 
@@ -341,9 +344,10 @@ suite("Shapeways.Client", function(){
     suite("client.addModelFile", function(){
         test("should build the correct url and call client.post", function(done){
             var old_post = shapeways.client.prototype.post;
-            shapeways.client.prototype.post = function(url, body, callback){
+            shapeways.client.prototype.post = function(url, body, content_type, callback){
                 assert.equal(url, "https://api.shapeways.com/models/86/files/v1");
                 assert.equal(typeof(body), "string");
+                assert.equal(typeof(content_type), "string");
                 callback(null, {});
             };
 
@@ -365,9 +369,10 @@ suite("Shapeways.Client", function(){
 
         test("should get error with missing params", function(done){
             var old_post = shapeways.client.prototype.post;
-            shapeways.client.prototype.post = function(url, body, callback){
+            shapeways.client.prototype.post = function(url, body, content_type, callback){
                 assert.equal(url, "https://api.shapeways.com/models/86/files/v1");
                 assert.equal(typeof(body), "string");
+                assert.equal(typeof(content_type), "string");
                 callback(null, {});
             };
 
@@ -484,9 +489,10 @@ suite("Shapeways.Client", function(){
     suite("client.updateModelInfo", function(){
         test("should build the correct url and call client.put", function(done){
             var old_put = shapeways.client.prototype.put;
-            shapeways.client.prototype.put = function(url, body, callback){
+            shapeways.client.prototype.put = function(url, body, content_type, callback){
                 assert.equal(url, "https://api.shapeways.com/models/86/v1");
                 assert.equal(typeof(body), "string");
+                assert.equal(typeof(content_type), "string");
                 callback(null, {});
             };
 
@@ -504,9 +510,10 @@ suite("Shapeways.Client", function(){
     suite("client.addModel", function(){
         test("should build the correct url and call client.post", function(done){
             var old_post = shapeways.client.prototype.post;
-            shapeways.client.prototype.post = function(url, body, callback){
+            shapeways.client.prototype.post = function(url, body, content_type, callback){
                 assert.equal(url, "https://api.shapeways.com/models/v1");
                 assert.equal(typeof(body), "string");
+                assert.equal(typeof(content_type), "string");
                 callback(null, {});
             };
 
@@ -528,9 +535,10 @@ suite("Shapeways.Client", function(){
 
         test("should get error with missing params", function(done){
             var old_post = shapeways.client.prototype.post;
-            shapeways.client.prototype.post = function(url, body, callback){
+            shapeways.client.prototype.post = function(url, body, content_type, callback){
                 assert.equal(url, "https://api.shapeways.com/models/v1");
                 assert.equal(typeof(body), "string");
+                assert.equal(typeof(content_type), "string");
                 callback(null, {});
             };
 

--- a/test/client/api.js
+++ b/test/client/api.js
@@ -394,9 +394,10 @@ suite("Shapeways.Client", function(){
     suite("client.addModelPhoto", function(){
         test("should build a correct url and call client.post", function(done){
             var old_post = shapeways.client.prototype.post;
-            shapeways.client.prototype.post = function(url, body, callback){
+            shapeways.client.prototype.post = function(url, body, content_type, callback){
                 assert.equal(url, "https://api.shapeways.com/models/86/photos/v1");
                 assert.equal(typeof(body), "string");
+                assert.equal(typeof(content_type), "string");
                 callback(null, {});
             };
 

--- a/test/client/request.js
+++ b/test/client/request.js
@@ -177,11 +177,12 @@ suite("Shapeways.Client", function(){
 
         test("should call client.connection.post", function(done){
             var old_post = oauth.OAuth.prototype.post;
-            oauth.OAuth.prototype.post = function(url, token, secret, body, callback){
+            oauth.OAuth.prototype.post = function(url, token, secret, body, content_type, callback){
                 assert.equal(url, "http://example.org/test");
                 assert.equal(token, "token");
                 assert.equal(secret, "secret");
                 assert.equal(body, null);
+                assert.equal(content_type, null);
                 callback(null, "{}");
             };
 
@@ -198,11 +199,12 @@ suite("Shapeways.Client", function(){
 
         test("should call client.connection.post with body", function(done){
             var old_post = oauth.OAuth.prototype.post;
-            oauth.OAuth.prototype.post = function(url, token, secret, body, callback){
+            oauth.OAuth.prototype.post = function(url, token, secret, body, content_type, callback){
                 assert.equal(url, "http://example.org/test");
                 assert.equal(token, "token");
                 assert.equal(secret, "secret");
                 assert.equal(body, '{"nice":"body"}');
+                assert.equal(content_type, null);
                 callback(null, "{}");
             };
 
@@ -219,11 +221,12 @@ suite("Shapeways.Client", function(){
 
         test("should get error from client.connection.post", function(done){
             var old_post = oauth.OAuth.prototype.post;
-            oauth.OAuth.prototype.post = function(url, token, secret, body, callback){
+            oauth.OAuth.prototype.post = function(url, token, secret, body, content_type, callback){
                 assert.equal(url, "http://example.org/test");
                 assert.equal(token, "token");
                 assert.equal(secret, "secret");
                 assert.equal(body, null);
+                assert.equal(content_type, null);
                 callback("an error");
             };
 
@@ -240,11 +243,12 @@ suite("Shapeways.Client", function(){
 
         test("should properly parse result from client.connection.post", function(done){
             var old_post = oauth.OAuth.prototype.post;
-            oauth.OAuth.prototype.post = function(url, token, secret, body, callback){
+            oauth.OAuth.prototype.post = function(url, token, secret, body, content_type, callback){
                 assert.equal(url, "http://example.org/test");
                 assert.equal(token, "token");
                 assert.equal(secret, "secret");
                 assert.equal(body, null);
+                assert.equal(content_type, null);
                 callback(null, '{"key":"value"}');
             };
 
@@ -286,11 +290,12 @@ suite("Shapeways.Client", function(){
 
         test("should call client.connection.put", function(done){
             var old_put = oauth.OAuth.prototype.put;
-            oauth.OAuth.prototype.put = function(url, token, secret, body, callback){
+            oauth.OAuth.prototype.put = function(url, token, secret, body, content_type, callback){
                 assert.equal(url, "http://example.org/test");
                 assert.equal(token, "token");
                 assert.equal(secret, "secret");
                 assert.equal(body, null);
+                assert.equal(content_type, null);
                 callback(null, "{}");
             };
 
@@ -307,11 +312,12 @@ suite("Shapeways.Client", function(){
 
         test("should call client.connection.put with body", function(done){
             var old_put = oauth.OAuth.prototype.put;
-            oauth.OAuth.prototype.put = function(url, token, secret, body, callback){
+            oauth.OAuth.prototype.put = function(url, token, secret, body, content_type, callback){
                 assert.equal(url, "http://example.org/test");
                 assert.equal(token, "token");
                 assert.equal(secret, "secret");
                 assert.equal(body, '{"nice":"body"}');
+                assert.equal(content_type, null);
                 callback(null, "{}");
             };
 
@@ -328,11 +334,12 @@ suite("Shapeways.Client", function(){
 
         test("should get error from client.connection.put", function(done){
             var old_put = oauth.OAuth.prototype.put;
-            oauth.OAuth.prototype.put = function(url, token, secret, body, callback){
+            oauth.OAuth.prototype.put = function(url, token, secret, body, content_type, callback){
                 assert.equal(url, "http://example.org/test");
                 assert.equal(token, "token");
                 assert.equal(secret, "secret");
                 assert.equal(body, null);
+                assert.equal(content_type, null);
                 callback("an error");
             };
 
@@ -349,11 +356,12 @@ suite("Shapeways.Client", function(){
 
         test("should properly parse result from client.connection.put", function(done){
             var old_put = oauth.OAuth.prototype.put;
-            oauth.OAuth.prototype.put = function(url, token, secret, body, callback){
+            oauth.OAuth.prototype.put = function(url, token, secret, body, content_type, callback){
                 assert.equal(url, "http://example.org/test");
                 assert.equal(token, "token");
                 assert.equal(secret, "secret");
                 assert.equal(body, null);
+                assert.equal(content_type, null);
                 callback(null, '{"key":"value"}');
             };
 


### PR DESCRIPTION
For certain POST and PUT requests, this specifies the content type as "application/json" (instead of the oauth module's default "application/x-www-form-urlencoded"). This seems to fix "signature invalid" errors.

---

Around the start of September, requests to Shapeways were failing because of "invalid signature" errors, this commit seems to fix those issues.

Note: this was only tested for the `addModel` method (as it's the only one I'm using), but it should apply to all requests that had `JSON.stringify` called on a javascript object and passed as the `body` argument.

---

Closes #7 

This was made possible using the suggestions made by @imdaveho and @RandomCouch. Thanks you two!
