### PR TITLE
Set proper content type for post API call

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -234,7 +234,7 @@ client.prototype.post = function(url, body, callback){
         return callback("no oauth token, make sure to call client.connect and client.verify");
     }
 
-    this.connection.post(url, this.oauthToken, this.oauthSecret, body, function(error, data, result){
+    this.connection.post(url, this.oauthToken, this.oauthSecret, body, 'application/json', function(error, data, result){
         if(error){
             return callback(error);
         }


### PR DESCRIPTION
Solves critical bug:
"result": "failure", "reason": "Authentication Error", "oauth_error_message": "oauth_problem=signature_invalid"